### PR TITLE
Add HasResourceRelations trait and convert LabOrders to use it

### DIFF
--- a/app/Http/Controllers/Api/LabOrderController.php
+++ b/app/Http/Controllers/Api/LabOrderController.php
@@ -56,7 +56,7 @@ class LabOrderController extends Controller
      */
     public function show(LabOrder $labOrder)
     {
-        $labOrder->load('patient', 'practice', 'lab');
+        $labOrder->loadResourceRelations();
 
         return LabOrderResource::make($labOrder);
     }
@@ -87,7 +87,7 @@ class LabOrderController extends Controller
         $labOrder->date_required = $date_required;
         $labOrder->save();
 
-        $labOrder->load('patient', 'practice', 'lab');
+        $labOrder->loadResourceRelations();
 
         return LabOrderResource::make($labOrder);
     }

--- a/app/Models/LabOrder.php
+++ b/app/Models/LabOrder.php
@@ -9,7 +9,7 @@ class LabOrder extends Model
 {
     use HasResourceRelations;
 
-    const RESOURCE_RELATIONS = ['patient', 'practice', 'lab'];
+    protected $resourceRelations = ['patient', 'practice', 'lab'];
 
     protected $guarded = ['id'];
 

--- a/app/Models/LabOrder.php
+++ b/app/Models/LabOrder.php
@@ -3,9 +3,14 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Traits\HasResourceRelations;
 
 class LabOrder extends Model
 {
+    use HasResourceRelations;
+
+    const RESOURCE_RELATIONS = ['patient', 'practice', 'lab'];
+
     protected $guarded = ['id'];
 
     public function patient()

--- a/app/Models/Traits/HasResourceRelations.php
+++ b/app/Models/Traits/HasResourceRelations.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models\Traits;
+
+trait HasResourceRelations
+{
+    protected function getResourceRelationsToLoad()
+    {
+        return defined('static::RESOURCE_RELATIONS')
+            ? static::RESOURCE_RELATIONS
+            : [];
+    }
+
+    public function loadResourceRelations()
+    {
+        $relations = $this->getResourceRelationsToLoad();
+
+        return $this->loadMissing($relations);
+    }
+}

--- a/app/Models/Traits/HasResourceRelations.php
+++ b/app/Models/Traits/HasResourceRelations.php
@@ -6,8 +6,8 @@ trait HasResourceRelations
 {
     protected function getResourceRelationsToLoad()
     {
-        return defined('static::RESOURCE_RELATIONS')
-            ? static::RESOURCE_RELATIONS
+        return isset($this->resourceRelations)
+            ? $this->resourceRelations
             : [];
     }
 


### PR DESCRIPTION
Allows us to move the relation loading out of the controllers and into the models.

```PHP
$labOrder->load('patient', 'practice', 'lab');

// becomes

$labOrder->loadResourceRelations();
```

To use it you need to just add the trait to a model, and define a property on the class called `$resourceRelations` and set it to an array of the relations we want to load:

```PHP
class LabOrder extends Model
{
    use HasResourceRelations;

    protected $resourceRelations = ['patient', 'practice', 'lab'];

   // ...
}
```

This way means if we ever want to change what relations are loaded, we only have to do it once in the model, rather than everywhere we call 'load', so it's just a little bit more reusable.